### PR TITLE
[DOC-REVIEW] Edit the netops & stocks Grafana dashboard tutorials doc [IG-1133 IG-10216]

### DIFF
--- a/demos/netops/grafana_demo.ipynb
+++ b/demos/netops/grafana_demo.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create Grafana data source and dashbord for the demo"
+    "# Create a Grafana Data Source and Dashboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Follow the steps in this this tutorial to define a custom \"iguazio\" Grafana data source and create a \"netops_metrics_jupyter\" Grafana dashboard that uses this data source to query tables in the Iguazio Data Science Platform (**\"the platform\"**)."
    ]
   },
   {
@@ -42,16 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# create a new dashboard\n",
-    "dash = Dashboard(\"netops_metrics_jupyter\", start='now-1d', dataSource='Iguazio')\n",
-    "\n",
-    "# create 6 charts (3 rows * 2 cols)\n",
-    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['cpu_utilization','latency']])\n",
-    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['throughput','packet_loss']])\n",
-    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['is_error', 'is_error']])\n",
-    "\n",
-    "# deploy to grafana\n",
-    "dash.deploy(grafana_url)"
+    "# Deploy the \"iguazio\" datasource with default paramaters/credentials.\n",
+    "# You need to do this only once.\n",
+    "ds=DataSource().deploy(grafana_url)"
    ]
   },
   {
@@ -59,7 +59,18 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Create a new Grafana dashboard\n",
+    "dash = Dashboard(\"netops_metrics_jupyter\", start='now-1d', dataSource='iguazio')\n",
+    "\n",
+    "# Create 6 charts (3 rows * 2 cols)\n",
+    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['cpu_utilization','latency']])\n",
+    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['throughput','packet_loss']])\n",
+    "dash.row([Graph(metric).series(table=\"netops_metrics_jupyter\", fields=[metric], container=\"bigdata\") for metric in ['is_error', 'is_error']])\n",
+    "\n",
+    "# Deploy to Grafana\n",
+    "dash.deploy(grafana_url)"
+   ]
   }
  ],
  "metadata": {

--- a/demos/stocks/grafana.ipynb
+++ b/demos/stocks/grafana.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create Grafana data source and dashbord for the demo"
+    "# Create a Grafana Data Source and Dashboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Follow the steps in this this tutorial to define a custom \"iguazio\" Grafana data source and create a \"stocks\" Grafana dashboard that uses this data source to query tables in the Iguazio Data Science Platform (**\"the platform\"**)."
    ]
   },
   {
@@ -42,7 +49,7 @@
    "source": [
     "# Grafana internal cluster address (will be http://grafana)\n",
     "grafana_url = 'http://10.97.225.197'\n",
-    "# stream viewer function EXTERNAL url\n",
+    "# External URL of the demo's stream-viewer Nuclio serverless function\n",
     "streamview_url = 'https://stream-view.iguazio.app.vjszzjiaingr.iguazio-cd0.com/'"
    ]
   },
@@ -52,8 +59,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# deploy iguazio datasource with default paramaters/credentials \n",
-    "# need to do only once\n",
+    "# Deploy the \"iguazio\" datasource with default paramaters/credentials.\n",
+    "# You need to do this only once.\n",
     "ds=DataSource().deploy(grafana_url)"
    ]
   },
@@ -71,30 +78,23 @@
     }
    ],
    "source": [
-    "# create a new dashboard\n",
+    "# Create a new Grafana dashboard\n",
     "dash = Dashboard(\"stocks\", start='now-1d', dataSource='iguazio')\n",
     "\n",
-    "# add a symbol combo box (template) with data from symbol table\n",
+    "# Add a symbol combo box (template) with data from the stocks table\n",
     "dash.template(name=\"SYMBOL\", label=\"Symbol\", query=\"fields=symbol;table=stocks;backend=kv;container=bigdata\")\n",
     "\n",
-    "# create table and log viewer in one row\n",
+    "# Create a table and log viewer in one row\n",
     "tbl = Table('tbl1',span=8).source(table='stocks',fields=['symbol','name','currency','price','last_trade','timezone','exchange'],container='bigdata')\n",
     "log = Ajax(title='Log',url=streamview_url)\n",
     "dash.row([tbl,log])\n",
     "\n",
-    "# create 3 charts on the 2nd row\n",
+    "# Create 3 charts on the second row\n",
     "dash.row([Graph(metric).series(table=\"stock_metrics\", fields=[metric], filter='symbol==\"$SYMBOL\"',container='bigdata') for metric in ['price','volume','sentiment']])\n",
     "\n",
-    "# deploy to grafana\n",
+    "# Deploy to Grafana\n",
     "dash.deploy(grafana_url)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
@adiso75 @yaronha FYI.
I'm merging the PR to allow new PRs based on these changes, but the PR changes should still be reviewed.

Adi, as I wrote you on Slack,
1. I plan to rename **demo/netops/grafana_demo.ipynb** to **grafana.ipynb** (like the stocks demo NB) as part of the NB and directories renaming effort.
2. My changes tn the **netops/grafana_dashboard.ipynb** NB also included the following code changes:
    1. Change the name of the data source from `"Iguazio"` to `"iguazio"` (as agreed with Haviv and as already done in the *stocks/grafana.ipynb* NB).
    2. Add a cell for the deployment of the "iguazio" data source (without execution output or numbering and with a code comment indicating that this needs to be done only once) — copied from the stocks demo.

Questions:
1. In the netops demo, why isn't there an execution output (and related execution-step numbering) for the last cell, which creates the dashboard (like in the stocks demo)?
2. For both demos, in the following code, is there a reason that we use double quotes for the dashboard name but single quotes for the values of the other string parameters? It looks bad.
`dash = Dashboard("stocks", start='now-1d', dataSource='iguazio')`
`dash = Dashboard(\"netops_metrics_jupyter\", start='now-1d', dataSource='iguazio')`