### PR TITLE
([DOC] Spark JDBC doc review [IG-11239 IG-12092]

### DIFF
--- a/getting-started/spark-jdbc.ipynb
+++ b/getting-started/spark-jdbc.ipynb
@@ -7,18 +7,22 @@
     "# Spark JDBC to Databases\n",
     "\n",
     "- [Overview](#spark-jdbc-overview)\n",
-    "  - [Prerequisites](#spark-jdbc-prerequisites)\n",
-    "- [Set Up](#spark-jdbc-setup)\n",
-    "- [Initiate Spark Session](#spark-jdbc-start-session)\n",
-    "- [Spark JDBC to Databases](#spark-jdbc-to-dbs)\n",
-    " - [Spark JDBC to MySQL](#spark-jdbc-to-mysql)\n",
-    " - [Spark JDBC to PostgreSQL](#spark-jdbc-to-postgresql)\n",
-    " - [Spark JDBC to Oracle](#spark-jdbc-to-oracle)\n",
-    " - [Spark JDBC to MS SQL Server](#spark-jdbc-to-ms-sql-server)\n",
-    " - [Spark JDBC to Redshift](#spark-jdbc-to-redshift)\n",
-    "- [Clean Up](#spark-jdbc-cleanup)\n",
+    "- [Setup](#spark-jdbc-setup)\n",
+    "  - [Define Environment Variables](#spark-jdbc-define-envir-vars)\n",
+    "  - [Initiate a Spark JDBC Session](#spark-jdbc-init-session)\n",
+    "    - [Load Driver Packages Dynamically](#spark-jdbc-init-dynamic-pkg-load)\n",
+    "    - [Load Driver Packages Locally](#spark-jdbc-init-local-pkg-load)\n",
+    "- [Connect to Databases Using Spark JDBC](#spark-jdbc-connect-to-dbs)\n",
+    " - [Connect to a MySQL Database](#spark-jdbc-to-mysql)\n",
+    "   - [Connecting to a Public MySQL Instance](#spark-jdbc-to-mysql-public)\n",
+    "   - [Connecting to a Test or Temporary MySQL Instance](#spark-jdbc-to-mysql-test-or-temp)\n",
+    " - [Connect to a PostgreSQL Database](#spark-jdbc-to-postgresql)\n",
+    " - [Connect to an Oracle Database](#spark-jdbc-to-oracle)\n",
+    " - [Connect to an MS SQL Server Database](#spark-jdbc-to-ms-sql-server)\n",
+    " - [Connect to a Redshift Database](#spark-jdbc-to-redshift)\n",
+    "- [Cleanup](#spark-jdbc-cleanup)\n",
     "  - [Delete Data](#spark-jdbc-delete-data)\n",
-    "  - [Stop the Spark Session](#spark-jdbc-stop-session)"
+    "  - [Release Spark Resources](#spark-jdbc-release-spark-resources)"
    ]
   },
   {
@@ -28,18 +32,9 @@
     "<a id=\"spark-jdbc-overview\"></a>\n",
     "## Overview\n",
     "\n",
-    "Spark SQL includes a data source that can read data from many databases using Java database connectivity (**JDBC**).\n",
+    "Spark SQL includes a data source that can read data from other databases using Java database connectivity (**JDBC**).\n",
     "The results are returned as a Spark DataFrame that can easily be processed in Spark SQL or joined with other data sources.\n",
-    "\n",
-    "<a id=\"spark-jdbc-prerequisites\"></a>\n",
-    "### Prerequisites\n",
-    "\n",
-    "In your **$SPARK_HOME/conf/spark-defaults.conf** configuration file, edit the following Spark properties to add the paths to your PostgrsSQL, MySQL, Oracle, and SQLServer JDBC-driver packages:\n",
-    "\n",
-    "- `spark.driver.extraClassPath`\n",
-    "- `spark.executor.extraClassPath`\n",
-    "\n",
-    "For more details, refer to the [Spark documentation](https://spark.apache.org/docs/2.3.1/sql-programming-guide.html#jdbc-to-other-databases)."
+    "For more information, see the [Spark documentation](https://spark.apache.org/docs/2.3.1/sql-programming-guide.html#jdbc-to-other-databases)."
    ]
   },
   {
@@ -47,7 +42,19 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-setup\"></a>\n",
-    "## Set UP"
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"spark-jdbc-define-envir-vars\"></a>\n",
+    "### Define Environment Variables\n",
+    "\n",
+    "Begin by initializing some environment variables.\n",
+    "\n",
+    "> **Note:** You need to edit the following code to assign valid values to the database variables (`DB_XXX`)."
    ]
   },
   {
@@ -72,19 +79,20 @@
    "source": [
     "import os\n",
     "\n",
-    "# Read Iguazio Data Science Platform (\"the platform\") environment variables\n",
+    "# Read Iguazio Data Science Platform (\"the platform\") environment variables into local variables\n",
     "V3IO_USER = os.getenv('V3IO_USERNAME')\n",
     "V3IO_HOME = os.getenv('V3IO_HOME')\n",
     "V3IO_HOME_URL = os.getenv('V3IO_HOME_URL')\n",
     "\n",
-    "# ADd database environment variables\n",
-    "%env DB_HOST = \"\"        # Database host's fully qualified name\n",
-    "%env DB_PORT = \"\"        # Port num of the database\n",
-    "%env DB_DRIVER = \"\"      # Database Driver [postgresql|mysql|oracle:thin|sqlserver]\n",
-    "%env DB_Name = \"\"        # Database|Schema Name\n",
-    "%env DB_TABLE = \"\"       # Table Name\n",
-    "%env DB_USER = \"\"        # Database User Name\n",
-    "%env DB_PASSWORD = \"\"    # Database User's Password\n",
+    "# Define database environment variables\n",
+    "# TODO: Edit the variable definitions to assign valid values for your environment.\n",
+    "%env DB_HOST = \"\"        # Database host as a fully qualified name (FQN)\n",
+    "%env DB_PORT = \"\"        # Database port number\n",
+    "%env DB_DRIVER = \"\"      # Database driver [mysql/postgresql|oracle:thin|sqlserver]\n",
+    "%env DB_Name = \"\"        # Database|schema name\n",
+    "%env DB_TABLE = \"\"       # Table name\n",
+    "%env DB_USER = \"\"        # Database username\n",
+    "%env DB_PASSWORD = \"\"    # Database user password\n",
     "\n",
     "os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages mysql:mysql-connector-java:5.1.39 pyspark-shell\""
    ]
@@ -93,8 +101,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"spark-jdbc-start-session\"></a>\n",
-    "## Initiate a Spark Session"
+    "<a id=\"spark-jdbc-init-session\"></a>\n",
+    "### Initiate a Spark JDBC Session\n",
+    "\n",
+    "You can select between two methods for initiating a Spark session with JDBC drivers (\"Spark JDBC session\"):\n",
+    "\n",
+    "- [Load Driver Packages Dynamically](#spark-jdbc-init-dynamic-pkg-load) (preferred)\n",
+    "- [Load Driver Packages Locally](#spark-jdbc-init-local-pkg-load)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"spark-jdbc-init-dynamic-pkg-load\"></a>\n",
+    "#### Load Driver Packages Dynamically\n",
+    "\n",
+    "The preferred method for initiating a Spark JDBC session is to load the required JDBC driver packages dynamically from https://spark-packages.org/ by doing the following:\n",
+    "\n",
+    "1. Set the `PYSPARK_SUBMIT_ARGS` environment variable to `\"--packages <group>:<name>:<version> pyspark-shell\"`.\n",
+    "2. Initiate a new spark session.\n",
+    "\n",
+    "The following example demonstrates how to initiate a Spark session that uses version 5.1.39 of the **mysql-connector-java** MySQL JDBC database driver (`mysql:mysql-connector-java:5.1.39`)."
    ]
   },
   {
@@ -106,40 +134,79 @@
     "from pyspark.conf import SparkConf\n",
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "# METHOD I:\n",
-    "#   Update Spark configurations of the following two extraClassPath with the JDBC driver location\n",
-    "#   prior to initiating a Spark session:\n",
-    "#      spark.driver.extraClassPath\n",
-    "#      spark.executor.extraClassPath\n",
-    "#\n",
-    "# NOTE:\n",
-    "# When connnecting to a different database than MySQL, replace the path to the MySQL JDBC connector\n",
-    "# in the following extraClassPat assignemnts with the path to the relevant JDBC DB connector.\n",
-    "#\n",
-    "# Initiate a Spark Session\n",
-    "spark = SparkSession.builder.\\\n",
-    "    appName(\"Spark JDBC to Databases - ipynb\").\\\n",
-    "    config(\"spark.driver.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\").\\\n",
-    "    config(\"spark.executor.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\").getOrCreate()\n",
+    "# Configure the Spark JDBC driver package\n",
+    "# TODO: Replace `mysql:mysql-connector-java:5.1.39` with the required driver-pacakge information.\n",
+    "os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages mysql:mysql-connector-java:5.1.39 pyspark-shell\"\n",
     "\n",
-    "# METHOD II:\n",
-    "#   Use \"PYSPARK_SUBMIT_ARGS\" with \"--packages\" option.  (The preferred way)\n",
-    "# \n",
-    "# Usage:\n",
-    "# os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages dialect:dialect-specific-jdbc-connector:version# pyspark-shell\"\n",
-    "#\n",
-    "# NOTE:\n",
-    "# If you don't connnect to mysql, replace the mysql's connector by the other database's JDBC connector \n",
-    "# in the following line.\n",
-    "# Set PYSPARK_SUBMIT_ARGS\n",
-    "#os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages mysql:mysql-connector-java:5.1.39 pyspark-shell\"\n",
+    "# Initiate a new Spark session; you can change the application name\n",
+    "spark = SparkSession.builder.appName(\"Spark JDBC tutorial\").getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"spark-jdbc-init-local-pkg-load\"></a>\n",
+    "#### Load Driver Packages Locally\n",
     "\n",
-    "# NOTE:\n",
-    "# If you use PYSPARK_SUBMIT_ARGS, use the following way to initiate the Spark session WITHOUT update:\n",
-    "#      spark.driver.extraClassPath\n",
-    "#      spark.executor.extraClassPath\n",
-    "# Initiate a Spark Session\n",
-    "#spark = SparkSession.builder.appName(\"Spark JDBC to Databases - ipynb\").getOrCreate()"
+    "You can also load the Spark JDBC driver package from the local file system of your Iguazio Data Science Platform (\"the platform\").\n",
+    "It's recommended that you use this method only if you don't have internet connection (\"dark-site installations\").\n",
+    "The platform comes pre-deployed with MySQL, PostgreSQL, Oracle, Redshift, and MS SQL Server JDBC driver packages, which are found in the **/spark/3rd_party** directory (**$SPARK_HOME/3rd_party**).\n",
+    "You can also copy additional driver packages or different versions of the pre-deployed drivers to the platform &mdash; for example, by from the **Data** dashboard page.\n",
+    "\n",
+    "To load a JDBC driver package locally, you need to set the `spark.driver.extraClassPath` and `spark.executor.extraClassPath` Spark configuration properties to the path to a Spark JDBC driver package in the platform's file system.\n",
+    "You can do this using either of the following alternative methods:\n",
+    "\n",
+    "- Preconfigure the path to the driver package &mdash;\n",
+    "\n",
+    "  1. In your Spark-configuration file &mdash; **$SPARK_HOME/conf/spark-defaults.conf** &mdash; set the `extraClassPath` configuration properties to the path to the relevant driver pacakge:\n",
+    "    ```\n",
+    "    spark.driver.extraClassPath = \"<path to a JDBC driver package>\"\n",
+    "    spark.executor.extraClassPath = \"<path to a JDBC driver package>\"\n",
+    "    ```\n",
+    "  2. Initiate a new spark session.\n",
+    "\n",
+    "- Configure the path to the driver package as part of the initiation of a new Spark session:\n",
+    "  ```\n",
+    "  spark = SparkSession.builder. \\\n",
+    "    appName(\"<app name>\"). \\\n",
+    "    config(\"spark.driver.extraClassPath\", \"<path to a JDBC driver package>\"). \\\n",
+    "    config(\"spark.executor.extraClassPath\", \"<path to a JDBC driver package>\"). \\\n",
+    "    getOrCreate()\n",
+    "  ```\n",
+    "\n",
+    "The following example demonstrates how to initiate a Spark session that uses the pre-deployed version 8.0.13 of the **mysql-connector-java** MySQL JDBC database driver (**/spark/3rd_party/mysql-connector-java-8.0.13.jar**)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.conf import SparkConf\n",
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "# METHOD I\n",
+    "# Edit your Spark configuration file ($SPARK_HOME/conf/spark-defaults.conf), set the `spark.driver.extraClassPath` and\n",
+    "# `spark.executor.extraClassPath` properties to the local file-system path to a pre-deployed Spark JDBC driver package.\n",
+    "# Replace \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\" with the relevant path.\n",
+    "#     spark.driver.extraClassPath = \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\"\n",
+    "#     spark.executor.extraClassPath = \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\"\n",
+    "#\n",
+    "# Then, initiate a new Spark session; you can change the application name.\n",
+    "# spark = SparkSession.builder.appName(\"Spark JDBC tutorial\").getOrCreate()\n",
+    "\n",
+    "# METHOD II\n",
+    "# Initiate a new Spark Session; you can change the application name.\n",
+    "# Set the same `extraClassPath` configuration properties as in Method #1 as part of the initiation command.\n",
+    "# Replace \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\" with the relevant path.\n",
+    "local file-system path to a pre-deployed Spark JDBC driver package\n",
+    "spark = SparkSession.builder. \\\n",
+    "    appName(\"Spark JDBC tutorial\"). \\\n",
+    "    config(\"spark.driver.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\"). \\\n",
+    "    config(\"spark.executor.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\"). \\\n",
+    "    getOrCreate()"
    ]
   },
   {
@@ -168,7 +235,7 @@
       " ('spark.executor.extraLibraryPath', '/hadoop/etc/hadoop'),\n",
       " ('spark.submit.pyFiles',\n",
       "  '/igz/.ivy2/jars/mysql_mysql-connector-java-5.1.39.jar'),\n",
-      " ('spark.app.name', 'Spark JDBC to Databases - ipynb'),\n",
+      " ('spark.app.name', 'Spark JDBC tutorial'),\n",
       " ('spark.repl.local.jars',\n",
       "  'file:///spark/v3io-libs/v3io-hcfs_2.11.jar,file:///spark/v3io-libs/v3io-spark2-object-dataframe_2.11.jar,file:///spark/v3io-libs/v3io-spark2-streaming_2.11.jar,file:///igz/.ivy2/jars/mysql_mysql-connector-java-5.1.39.jar'),\n",
       " ('spark.rdd.compress', 'True'),\n",
@@ -189,8 +256,8 @@
    "source": [
     "import pprint\n",
     "\n",
-    "# List Spark configurations.\n",
-    "# Check the output and verify that the JDBC-drivers path was properly added to both the Spark driver and executor extraClassPath configuration.\n",
+    "# Verify your configuration: run the following code to list the current Spark configurations, and check the output to verify that the\n",
+    "# `spark.driver.extraClassPath` and `spark.executor.extraClassPath` properties are set to the correct local driver-pacakge path.\n",
     "conf = spark.sparkContext._conf.getAll()\n",
     "\n",
     "pprint.pprint(conf)"
@@ -200,8 +267,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"spark-jdbc-to-dbs\"></a>\n",
-    "## Spark JDBC to Databases"
+    "<a id=\"spark-jdbc-connect-to-dbs\"></a>\n",
+    "## Connect to Databases Using Spark JDBC"
    ]
   },
   {
@@ -209,7 +276,7 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-mysql\"></a>\n",
-    "### Spark JDBC to MySQL\n",
+    "### Connect to a MySQL Database\n",
     "\n",
     "- [Connecting to a Public MySQL Instance](#spark-jdbc-to-mysql-public)\n",
     "- [Connecting to a Test or Temporary MySQL Instance](#spark-jdbc-to-mysql-test-or-temp)"
@@ -220,7 +287,7 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-mysql-public\"></a>\n",
-    "#### Connecting to a Public MySQL Instance"
+    "#### Connect to a Public MySQL Instance"
    ]
   },
   {
@@ -280,7 +347,7 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-mysql-test-or-temp\"></a>\n",
-    "#### Connecting to a Test or Temporary MySQL Instance\n",
+    "#### Connect to a Test or Temporary MySQL Instance\n",
     "\n",
     "> **Note:** The following code won't work if the MySQL instance has been shut down."
    ]
@@ -308,14 +375,16 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-postgresql\"></a>\n",
-    "### Spark JDBC to PostgreSQL"
+    "### Connect to a PostgreSQL Database"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "#Loading data from a JDBC source\n",
+    "# Load data from a JDBC source\n",
     "dfPS = spark.read \\\n",
     "    .format(\"jdbc\") \\\n",
     "    .option(\"url\", \"jdbc:postgresql:dbserver\") \\\n",
@@ -328,7 +397,7 @@
     "    .jdbc(\"jdbc:postgresql:dbserver\", \"schema.tablename\",\n",
     "    properties={\"user\": \"username\", \"password\": \"password\"})\n",
     "\n",
-    "# Specifying dataframe column data types on read\n",
+    "# Specify DataFrame column data types on read\n",
     "dfPS3 = spark.read \\\n",
     "    .format(\"jdbc\") \\\n",
     "    .option(\"url\", \"jdbc:postgresql:dbserver\") \\\n",
@@ -338,7 +407,7 @@
     "    .option(\"customSchema\", \"id DECIMAL(38, 0), name STRING\") \\\n",
     "    .load()\n",
     "\n",
-    "# Saving data to a JDBC source\n",
+    "# Save data to a JDBC source\n",
     "dfPS.write \\\n",
     "    .format(\"jdbc\") \\\n",
     "    .option(\"url\", \"jdbc:postgresql:dbserver\") \\\n",
@@ -350,7 +419,7 @@
     "dfPS2.write \\\n",
     "    properties={\"user\": \"username\", \"password\": \"password\"})\n",
     "\n",
-    "# Specifying create table column data types on write\n",
+    "# Specify create table column data types on write\n",
     "dfPS.write \\\n",
     "    .option(\"createTableColumnTypes\", \"name CHAR(64), comments VARCHAR(1024)\") \\\n",
     "    .jdbc(\"jdbc:postgresql:dbserver\", \"schema.tablename\", properties={\"user\": \"username\", \"password\": \"password\"})"
@@ -361,14 +430,16 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-oracle\"></a>\n",
-    "### Spark JDBC to Oracle"
+    "### Connect to an Oracle Database"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Read a table from Orale (table: hr.emp)\n",
+    "# Read a table from Oracle (table: hr.emp)\n",
     "dfORA = spark.read \\\n",
     "    .format(\"jdbc\") \\\n",
     "    .option(\"url\", \"jdbc:oracle:thin:username/password@//hostname:portnumber/SID\") \\\n",
@@ -382,7 +453,7 @@
     "\n",
     "dfORA.show()\n",
     "\n",
-    "# Read a query from Orale\n",
+    "# Read a query from Oracle\n",
     "query = \"(select empno,ename,dname from emp, dept where emp.deptno = dept.deptno) emp\"\n",
     "\n",
     "dfORA1 = spark.read \\\n",
@@ -404,12 +475,14 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-ms-sql-server\"></a>\n",
-    "### Spark JDBC to MS SQL Server"
+    "### Connect to an MS SQL Server Database"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Read a table from MS SQL Server\n",
     "dfMS = spark.read \\\n",
@@ -431,7 +504,7 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-to-redshift\"></a>\n",
-    "### Spark JDBC to Redshift"
+    "### Connect to a Redshift Database"
    ]
   },
   {
@@ -481,12 +554,12 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-cleanup\"></a>\n",
-    "## Clean UP\n",
+    "## Cleanup\n",
     "\n",
     "Prior to exiting, release disk space, computation, and memory resources consumed by the active session:\n",
     "\n",
     "- [Delete Data](#spark-jdbc-delete-data)\n",
-    "- [Stop the Spark Session](#spark-jdbc-stop-session)"
+    "- [Release Spark Resources](#spark-jdbc-release-spark-resources)"
    ]
   },
   {
@@ -494,7 +567,12 @@
    "metadata": {},
    "source": [
     "<a id=\"spark-jdbc-delete-data\"></a>\n",
-    "### Delete Data"
+    "### Delete Data\n",
+    "\n",
+    "You can optionally delete any of the directories or files that you created.\n",
+    "See the instructions in the [Creating and Deleting Container Directories](https://www.iguazio.com/docs/tutorials/latest-release/getting-started/containers/#create-delete-container-dirs) tutorial.\n",
+    "For example, the following code uses a local file-system command to delete a **&lt;running user&gt;/examples/spark-jdbc** directory in the \"users\" container.\n",
+    "Edit the path, as needed, then remove the comment mark (`#`) and run the code."
    ]
   },
   {
@@ -503,16 +581,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Edit the path in the following command and unmark the comment to delete unnecessary files:\n",
-    "# !rm -rf $HOME/PATH/*"
+    "# !rm -rf /User/examples/spark-jdbc/"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"spark-jdbc-stop-session\"></a>\n",
-    "### Stop the Spark Session"
+    "<a id=\"spark-jdbc-release-spark-resources\"></a>\n",
+    "### Release Spark Resources\n",
+    "\n",
+    "When you're done, run the following command to stop your Spark session and release its computation and memory resources:"
    ]
   },
   {

--- a/getting-started/spark-jdbc.ipynb
+++ b/getting-started/spark-jdbc.ipynb
@@ -6,39 +6,48 @@
    "source": [
     "# Spark JDBC to Databases\n",
     "\n",
-    "1. [Overview](#Overview)\n",
-    "2. [Set Up](#Set-UP)\n",
-    "3. [Initiate Spark Session](#Initiate-Spark-Session)\n",
-    "4. [Spark JDBC to Databases](#Spark-JDBC-to-Databases)\n",
-    "    1. [Spark JDBC to MySQL](#Spark-JDBC-to-MySQL)\n",
-    "    2. [Spark JDBC to PostgreSQL](#Spark-JDBC-to-PostgreSQL)\n",
-    "    3. [Spark JDBC to Oracle](#Spark-JDBC-to-Oracle)\n",
-    "    4. [Spark JDBC to MS SQL Server](#Spark-JDBC-to-MS-SQL-Server)\n",
-    "    5. [Spark JDBC to Redshift](#Spark-JDBC-to-Redshift)\n",
-    "5. [Clean Up](#Clean-Up)\n"
+    "- [Overview](#spark-jdbc-overview)\n",
+    "  - [Prerequisites](#spark-jdbc-prerequisites)\n",
+    "- [Set Up](#spark-jdbc-setup)\n",
+    "- [Initiate Spark Session](#spark-jdbc-start-session)\n",
+    "- [Spark JDBC to Databases](#spark-jdbc-to-dbs)\n",
+    " - [Spark JDBC to MySQL](#spark-jdbc-to-mysql)\n",
+    " - [Spark JDBC to PostgreSQL](#spark-jdbc-to-postgresql)\n",
+    " - [Spark JDBC to Oracle](#spark-jdbc-to-oracle)\n",
+    " - [Spark JDBC to MS SQL Server](#spark-jdbc-to-ms-sql-server)\n",
+    " - [Spark JDBC to Redshift](#spark-jdbc-to-redshift)\n",
+    "- [Clean Up](#spark-jdbc-cleanup)\n",
+    "  - [Delete Data](#spark-jdbc-delete-data)\n",
+    "  - [Stop the Spark Session](#spark-jdbc-stop-session)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Overview\n",
+    "<a id=\"spark-jdbc-overview\"></a>\n",
+    "## Overview\n",
     "\n",
-    "Spark SQL includes a data source that can read data from many databases using JDBC.  The results are returned as a DataFrame that can easily be processed in Spark SQL or joined with other data sources. <br>\n",
+    "Spark SQL includes a data source that can read data from many databases using Java database connectivity (**JDBC**).\n",
+    "The results are returned as a Spark DataFrame that can easily be processed in Spark SQL or joined with other data sources.\n",
     "\n",
-    "**Prerequisites** <br>\n",
-    "In SPARK_HOME/conf/spark-default.conf file, add path of JDBC drivers for PostgrsSQL, MySQL, Oracle, and SQLServer to the following two Spark properties : \n",
-    "* spark.driver.extraClassPath\n",
-    "* spark.executor.extraClassPath\n",
+    "<a id=\"spark-jdbc-prerequisites\"></a>\n",
+    "### Prerequisites\n",
     "\n",
-    "For more details read [Spark JDBC to Databases](https://spark.apache.org/docs/2.3.1/sql-programming-guide.html#jdbc-to-other-databases)"
+    "In your **$SPARK_HOME/conf/spark-defaults.conf** configuration file, edit the following Spark properties to add the paths to your PostgrsSQL, MySQL, Oracle, and SQLServer JDBC-driver packages:\n",
+    "\n",
+    "- `spark.driver.extraClassPath`\n",
+    "- `spark.executor.extraClassPath`\n",
+    "\n",
+    "For more details, refer to the [Spark documentation](https://spark.apache.org/docs/2.3.1/sql-programming-guide.html#jdbc-to-other-databases)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Set UP"
+    "<a id=\"spark-jdbc-setup\"></a>\n",
+    "## Set UP"
    ]
   },
   {
@@ -52,30 +61,30 @@
      "text": [
       "env: DB_HOST=\"\"        # Database host's fully qualified name\n",
       "env: DB_PORT=\"\"        # Port num of the database\n",
-      "env: DB_DRIVER=\"\"        # Database Driver [postgresql|mysql|oracle:thin|sqlserver]\n",
+      "env: DB_DRIVER=\"\"      # Database Driver [postgresql|mysql|oracle:thin|sqlserver]\n",
       "env: DB_Name=\"\"        # Database|Schema Name\n",
-      "env: DB_TABLE=\"\"        # Table Name\n",
+      "env: DB_TABLE=\"\"       # Table Name\n",
       "env: DB_USER=\"\"        # Database User Name\n",
-      "env: DB_PASSWORD=\"\"        # Database User's Password\n"
+      "env: DB_PASSWORD=\"\"    # Database User's Password\n"
      ]
     }
    ],
    "source": [
     "import os\n",
     "\n",
-    "# Iguazio env\n",
+    "# Read Iguazio Data Science Platform (\"the platform\") environment variables\n",
     "V3IO_USER = os.getenv('V3IO_USERNAME')\n",
     "V3IO_HOME = os.getenv('V3IO_HOME')\n",
     "V3IO_HOME_URL = os.getenv('V3IO_HOME_URL')\n",
     "\n",
-    "# Database properties\n",
+    "# ADd database environment variables\n",
     "%env DB_HOST = \"\"        # Database host's fully qualified name\n",
     "%env DB_PORT = \"\"        # Port num of the database\n",
-    "%env DB_DRIVER = \"\"        # Database Driver [postgresql|mysql|oracle:thin|sqlserver]\n",
+    "%env DB_DRIVER = \"\"      # Database Driver [postgresql|mysql|oracle:thin|sqlserver]\n",
     "%env DB_Name = \"\"        # Database|Schema Name\n",
-    "%env DB_TABLE = \"\"        # Table Name\n",
+    "%env DB_TABLE = \"\"       # Table Name\n",
     "%env DB_USER = \"\"        # Database User Name\n",
-    "%env DB_PASSWORD = \"\"        # Database User's Password\n",
+    "%env DB_PASSWORD = \"\"    # Database User's Password\n",
     "\n",
     "os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages mysql:mysql-connector-java:5.1.39 pyspark-shell\""
    ]
@@ -84,25 +93,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initiate Spark Session"
+    "<a id=\"spark-jdbc-start-session\"></a>\n",
+    "## Initiate a Spark Session"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\n# NOTE:\\n# If you use PYSPARK_SUBMIT_ARGS, use the following way to initiate the Spark session WITHOUT update:\\n#      spark.driver.extraClassPath\\n#      spark.executor.extraClassPath\\n'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyspark.conf import SparkConf\n",
     "from pyspark.sql import SparkSession\n",
@@ -114,8 +113,8 @@
     "#      spark.executor.extraClassPath\n",
     "#\n",
     "# NOTE:\n",
-    "# If you don't connnect to mysql, replace the mysql's connector by the other database's JDBC connector \n",
-    "# in the following two extraClassPath.\n",
+    "# When connnecting to a different database than MySQL, replace the path to the MySQL JDBC connector\n",
+    "# in the following extraClassPat assignemnts with the path to the relevant JDBC DB connector.\n",
     "#\n",
     "# Initiate a Spark Session\n",
     "spark = SparkSession.builder.\\\n",
@@ -123,7 +122,6 @@
     "    config(\"spark.driver.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\").\\\n",
     "    config(\"spark.executor.extraClassPath\", \"/spark/3rd_party/mysql-connector-java-8.0.13.jar\").getOrCreate()\n",
     "\n",
-    "\"\"\"\n",
     "# METHOD II:\n",
     "#   Use \"PYSPARK_SUBMIT_ARGS\" with \"--packages\" option.  (The preferred way)\n",
     "# \n",
@@ -133,16 +131,13 @@
     "# NOTE:\n",
     "# If you don't connnect to mysql, replace the mysql's connector by the other database's JDBC connector \n",
     "# in the following line.\n",
-    "\"\"\"\n",
     "# Set PYSPARK_SUBMIT_ARGS\n",
     "#os.environ[\"PYSPARK_SUBMIT_ARGS\"] = \"--packages mysql:mysql-connector-java:5.1.39 pyspark-shell\"\n",
     "\n",
-    "\"\"\"\n",
     "# NOTE:\n",
     "# If you use PYSPARK_SUBMIT_ARGS, use the following way to initiate the Spark session WITHOUT update:\n",
     "#      spark.driver.extraClassPath\n",
     "#      spark.executor.extraClassPath\n",
-    "\"\"\"  \n",
     "# Initiate a Spark Session\n",
     "#spark = SparkSession.builder.appName(\"Spark JDBC to Databases - ipynb\").getOrCreate()"
    ]
@@ -194,8 +189,8 @@
    "source": [
     "import pprint\n",
     "\n",
-    "# List Spark configurations\n",
-    "# Verify if JDBC drivers' path was properly added to both of Spark driver and executor extra LibPath.\n",
+    "# List Spark configurations.\n",
+    "# Check the output and verify that the JDBC-drivers path was properly added to both the Spark driver and executor extraClassPath configuration.\n",
     "conf = spark.sparkContext._conf.getAll()\n",
     "\n",
     "pprint.pprint(conf)"
@@ -205,21 +200,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Spark JDBC to Databases"
+    "<a id=\"spark-jdbc-to-dbs\"></a>\n",
+    "## Spark JDBC to Databases"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spark JDBC to MySQL"
+    "<a id=\"spark-jdbc-to-mysql\"></a>\n",
+    "### Spark JDBC to MySQL\n",
+    "\n",
+    "- [Connecting to a Public MySQL Instance](#spark-jdbc-to-mysql-public)\n",
+    "- [Connecting to a Test or Temporary MySQL Instance](#spark-jdbc-to-mysql-test-or-temp)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Connecting to a public mySQL instance"
+    "<a id=\"spark-jdbc-to-mysql-public\"></a>\n",
+    "#### Connecting to a Public MySQL Instance"
    ]
   },
   {
@@ -278,8 +279,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Connecting to a testing/temporary mySQL instance\n",
-    "**NOTE** It won't work, when this tesing mySQL instance was shutdown."
+    "<a id=\"spark-jdbc-to-mysql-test-or-temp\"></a>\n",
+    "#### Connecting to a Test or Temporary MySQL Instance\n",
+    "\n",
+    "> **Note:** The following code won't work if the MySQL instance has been shut down."
    ]
   },
   {
@@ -304,7 +307,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spark JDBC to PostgreSQL"
+    "<a id=\"spark-jdbc-to-postgresql\"></a>\n",
+    "### Spark JDBC to PostgreSQL"
    ]
   },
   {
@@ -356,7 +360,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spark JDBC to Oracle"
+    "<a id=\"spark-jdbc-to-oracle\"></a>\n",
+    "### Spark JDBC to Oracle"
    ]
   },
   {
@@ -398,7 +403,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spark JDBC to MS SQL Server"
+    "<a id=\"spark-jdbc-to-ms-sql-server\"></a>\n",
+    "### Spark JDBC to MS SQL Server"
    ]
   },
   {
@@ -424,7 +430,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spark JDBC to Redshift"
+    "<a id=\"spark-jdbc-to-redshift\"></a>\n",
+    "### Spark JDBC to Redshift"
    ]
   },
   {
@@ -449,7 +456,7 @@
     "    .option(\"tempdir\", \"s3n://path/for/temp/data\") \\\n",
     "    .load()\n",
     "\n",
-    "# Write back to a table\n",
+    "# Write data back to a table\n",
     "dfRS.write \\\n",
     "  .format(\"com.databricks.spark.redshift\") \\\n",
     "  .option(\"url\", \"jdbc:redshift://redshifthost:5439/database?user=username&password=pass\") \\\n",
@@ -458,7 +465,7 @@
     "  .mode(\"error\") \\\n",
     "  .save()\n",
     "\n",
-    "# Using IAM Role based authentication\n",
+    "# Use IAM role-based authentication\n",
     "dfRS.write \\\n",
     "  .format(\"com.databricks.spark.redshift\") \\\n",
     "  .option(\"url\", \"jdbc:redshift://redshifthost:5439/database?user=username&password=pass\") \\\n",
@@ -473,15 +480,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Clean UP\n",
-    "Prior to exiting, let's run housekeeping to release disk space, computation and memory resources taken by this session. <br>"
+    "<a id=\"spark-jdbc-cleanup\"></a>\n",
+    "## Clean UP\n",
+    "\n",
+    "Prior to exiting, release disk space, computation, and memory resources consumed by the active session:\n",
+    "\n",
+    "- [Delete Data](#spark-jdbc-delete-data)\n",
+    "- [Stop the Spark Session](#spark-jdbc-stop-session)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Remove Data"
+    "<a id=\"spark-jdbc-delete-data\"></a>\n",
+    "### Delete Data"
    ]
   },
   {
@@ -490,7 +503,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unmark the comment\n",
+    "# Edit the path in the following command and unmark the comment to delete unnecessary files:\n",
     "# !rm -rf $HOME/PATH/*"
    ]
   },
@@ -498,7 +511,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Stop Spark Session"
+    "<a id=\"spark-jdbc-stop-session\"></a>\n",
+    "### Stop the Spark Session"
    ]
   },
   {


### PR DESCRIPTION
@gshatz @adiso75 please approve my doc-review changes to the Spark JDBC getting-started tutorial notebook. I'll merge the PR once you both approve.

**NOTE:** The example code currently loads **v5.1.39** of the *mysql-connector` package in the dynamic-loading example but **v8.0.13** in the local pre-deployed package load example (as this is apparently the pre-deployed version). I think it would be better to use the same version for both examples — i.e., change the version of the dynamic-loading example to v8.0.13. @gshatz confirmed that makes sense he needs to verify that this version exists in the https://spark-packages.org/ repo that's used with the dynamic-loading method (`--packages`). For now, I didn't change the versions.