### PR TITLE
[DOC] Image-classification demo: doc review for the README demo overviews [IG-12092]

### DIFF
--- a/demos/README.ipynb
+++ b/demos/README.ipynb
@@ -38,17 +38,15 @@
     "<a id=\"image-classification-demo\"></a>\n",
     "## Image Classification\n",
     "\n",
-    "The [**image-classification**](image-classification/01-image-classification.ipynb) demo demonstrates image recognition: the application builds and trains an ML model that identifies (recognizes) and classifies images.\n",
+    "The [**image-classification**](image-classification/01-image-classification.ipynb) demo demonstrates an end-to-end solution for image recognition: the application uses TensorFlow, Keras, Horovod, and Nuclio to build and train an ML model that identifies (recognizes) and classifies images. \n",
+    "The application consists of four MLRun and Nuclio functions for performing the following operations:\n",
     "\n",
-    "This example is using TensorFlow, Horovod, and Nuclio demonstrating end to end solution for image classification, \n",
-    "it consists of 4 MLRun and Nuclio functions:\n",
+    "1. Import an image archive from from an Amazon Simple Storage (S3) bucket to the platform's data store.\n",
+    "2. Tag the images based on their name structure.\n",
+    "3. Train the image-classification ML model by using [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/); use [Horovod](https://eng.uber.com/horovod/) to perform distributed training over either GPUs or CPUs.\n",
+    "4. Automatically deploy a Nuclio model-serving function from [Jupyter Notebook](nuclio-serving-tf-images.ipynb) or from a [Dockerfile](./inference-docker).\n",
     "\n",
-    "1. import an image archive from S3 to the cluster file system\n",
-    "2. Tag the images based on their name structure \n",
-    "3. Distrubuted training using TF, Keras and Horovod\n",
-    "4. Automated deployment of Nuclio model serving function (form [Notebook](nuclio-serving-tf-images.ipynb) and from [Dockerfile](./inference-docker))\n",
-    "\n",
-    "The Example also demonstrate an [automated pipeline](mlrun_mpijob_pipe.ipynb) using MLRun and KubeFlow pipelines "
+    "This demo also provides an example of an [automated pipeline](image-classification/02-create_pipeline.ipynb) using [MLRun](https://github.com/mlrun/mlrun) and [Kubeflow pipelines](https://github.com/kubeflow/pipelines)."
    ]
   },
   {

--- a/demos/README.md
+++ b/demos/README.md
@@ -17,17 +17,15 @@ The **demos** tutorials directory contains full end-to-end use-case applications
 <a id="image-classification-demo"></a>
 ## Image Classification
 
-The [**image-classification**](image-classification/01-image-classification.ipynb) demo demonstrates image recognition: the application builds and trains an ML model that identifies (recognizes) and classifies images.
+The [**image-classification**](image-classification/01-image-classification.ipynb) demo demonstrates an end-to-end solution for image recognition: the application uses TensorFlow, Keras, Horovod, and Nuclio to build and train an ML model that identifies (recognizes) and classifies images. 
+The application consists of four MLRun and Nuclio functions for performing the following operations:
 
-This example is using TensorFlow, Horovod, and Nuclio demonstrating end to end solution for image classification, 
-it consists of 4 MLRun and Nuclio functions:
+1. Import an image archive from from an Amazon Simple Storage (S3) bucket to the platform's data store.
+2. Tag the images based on their name structure.
+3. Train the image-classification ML model by using [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/); use [Horovod](https://eng.uber.com/horovod/) to perform distributed training over either GPUs or CPUs.
+4. Automatically deploy a Nuclio model-serving function from [Jupyter Notebook](nuclio-serving-tf-images.ipynb) or from a [Dockerfile](./inference-docker).
 
-1. import an image archive from S3 to the cluster file system
-2. Tag the images based on their name structure 
-3. Distrubuted training using TF, Keras and Horovod
-4. Automated deployment of Nuclio model serving function (form [Notebook](nuclio-serving-tf-images.ipynb) and from [Dockerfile](./inference-docker))
-
-The Example also demonstrate an [automated pipeline](mlrun_mpijob_pipe.ipynb) using MLRun and KubeFlow pipelines 
+This demo also provides an example of an [automated pipeline](image-classification/02-create_pipeline.ipynb) using [MLRun](https://github.com/mlrun/mlrun) and [Kubeflow pipelines](https://github.com/kubeflow/pipelines).
 
 <a id="netops-demo"></a>
 ## Predictive Infrastructure Monitoring

--- a/demos/image-classification/README.ipynb
+++ b/demos/image-classification/README.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Image Classification Using Distributed Training\n",
+    "\n",
+    "- [Overview](#image-classif-demo-overview)\n",
+    "- [Notebooks and Code](#image-classif-demo-nbs-n-code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"image-classif-demo-overview\"></a>\n",
+    "## Overview\n",
+    "\n",
+    "This demo demonstrates an end-to-end solution for image recognition: the application uses TensorFlow, Keras, Horovod, and Nuclio to build and train an ML model that identifies (recognizes) and classifies images. \n",
+    "The application consists of four MLRun and Nuclio functions for performing the following operations:\n",
+    "\n",
+    "1. Import an image archive from from an Amazon Simple Storage (S3) bucket to the platform's data store.\n",
+    "2. Tag the images based on their name structure.\n",
+    "3. Train the image-classification ML model by using [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/); use [Horovod](https://eng.uber.com/horovod/) to perform distributed training over either GPUs or CPUs.\n",
+    "4. Automatically deploy a Nuclio model-serving function from [Jupyter Notebook](nuclio-serving-tf-images.ipynb) or from a [Dockerfile](./inference-docker).\n",
+    "\n",
+    "<br><p align=\"center\"><img src=\"workflow.png\" width=\"600\"/></p><br>\n",
+    "\n",
+    "This demo also provides an example of an [automated pipeline](image-classification/02-create_pipeline.ipynb) using [MLRun](https://github.com/mlrun/mlrun) and [Kubeflow pipelines](https://github.com/kubeflow/pipelines)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"image-classif-demo-nbs-n-code\"></a>\n",
+    "## Notebooks and Code\n",
+    "\n",
+    "- [**01-image-classification.ipynb**](01-image-classification.ipynb) &mdash; all-in-one: import, tag, launch train, deploy, and serve\n",
+    "- [**horovod-training.py**](horovod-training.py) &mdash; train function code\n",
+    "- [**nuclio-serving-tf-images.ipynb**](nuclio-serving-tf-images.ipynb) &mdash; serve function development and test\n",
+    "- [**02-create_pipeline.ipynb**](02-create_pipeline.ipynb) &mdash; auto-generate a Kubeflow pipeline workflow\n",
+    "- **inference-docker/** &mdash; build and serve functions using a Dockerfile:\n",
+    "  - [**main.py**](./inference-docker/main.py) &mdash; function code\n",
+    "  - [**Dockerfile**](./inference-docker/Dockerfile) &mdash; a Dockerfile"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/demos/image-classification/README.md
+++ b/demos/image-classification/README.md
@@ -1,24 +1,30 @@
 # Image Classification Using Distributed Training
 
-This example is using TensorFlow, Horovod, and Nuclio demonstrating end to end solution for image classification, 
-it consists of 4 MLRun and Nuclio functions:
+- [Overview](#image-classif-demo-overview)
+- [Notebooks and Code](#image-classif-demo-nbs-n-code)
 
-1. import an image archive from S3 to the cluster file system
-2. Tag the images based on their name structure 
-3. Distrubuted training using TF, Keras and Horovod
-4. Automated deployment of Nuclio model serving function (form [Notebook](nuclio-serving-tf-images.ipynb) and from [Dockerfile](./inference-docker))
+<a id="image-classif-demo-overview"></a>
+## Overview
+
+This demo demonstrates an end-to-end solution for image recognition: the application uses TensorFlow, Keras, Horovod, and Nuclio to build and train an ML model that identifies (recognizes) and classifies images. 
+The application consists of four MLRun and Nuclio functions for performing the following operations:
+
+1. Import an image archive from from an Amazon Simple Storage (S3) bucket to the platform's data store.
+2. Tag the images based on their name structure.
+3. Train the image-classification ML model by using [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/); use [Horovod](https://eng.uber.com/horovod/) to perform distributed training over either GPUs or CPUs.
+4. Automatically deploy a Nuclio model-serving function from [Jupyter Notebook](nuclio-serving-tf-images.ipynb) or from a [Dockerfile](./inference-docker).
 
 <br><p align="center"><img src="workflow.png" width="600"/></p><br>
 
-The Example also demonstrate an [automated pipeline](mlrun_mpijob_pipe.ipynb) using MLRun and KubeFlow pipelines 
+This demo also provides an example of an [automated pipeline](image-classification/02-create_pipeline.ipynb) using [MLRun](https://github.com/mlrun/mlrun) and [Kubeflow pipelines](https://github.com/kubeflow/pipelines).
 
-## Notebooks & Code
+<a id="image-classif-demo-nbs-n-code"></a>
+## Notebooks and Code
 
-* [All-in-one: Import, tag, launch training, deploy serving](01-image-classification.ipynb) 
-* [Training function code](horovod-training.py)
-* [Serving function development and testing](nuclio-serving-tf-images.ipynb)
-* [Auto generation of KubeFlow pipelines workflow](02-create_pipeline.ipynb)
-* [Building serving function using Dockerfile](./inference-docker)
-  * [function code](./inference-docker/main.py)
-  * [Dockerfile](./inference-docker/Dockerfile)
-
+- [**01-image-classification.ipynb**](01-image-classification.ipynb) &mdash; all-in-one: import, tag, launch train, deploy, and serve
+- [**horovod-training.py**](horovod-training.py) &mdash; train function code
+- [**nuclio-serving-tf-images.ipynb**](nuclio-serving-tf-images.ipynb) &mdash; serve function development and test
+- [**02-create_pipeline.ipynb**](02-create_pipeline.ipynb) &mdash; auto-generate a Kubeflow pipeline workflow
+- **inference-docker/** &mdash; build and serve functions using a Dockerfile:
+  - [**main.py**](./inference-docker/main.py) &mdash; function code
+  - [**Dockerfile**](./inference-docker/Dockerfile) &mdash; a Dockerfile


### PR DESCRIPTION
This PR includes a doc review for the image-classification demo overview edits done in PR #160 and of the **image-classification/README.md** + I added an **image-classification/README.ipynb** NB (from which the MD file should now be exported).

@adiso75 please review.
You can also view the updated README NBs/MD files on my PR fork — https://github.com/Sharon-iguazio/tutorials/tree/doc-image-classif-demo-readme-overviews/demos.