### PR TITLE
[DOC] Frames GS: `kv` `write` - don't assign return value [IG-12272 IG-12092]

### DIFF
--- a/getting-started/frames.ipynb
+++ b/getting-started/frames.ipynb
@@ -324,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = client.write(\"kv\", table=table, dfs=df)"
+    "client.write(\"kv\", table=table, dfs=df)"
    ]
   },
   {


### PR DESCRIPTION
@adiso75  as discussed, I removed the assignment of the `write` return value for the `"kv"` backend to a variable; (the value of the return-value variable — `out` — was `None` and it was not used).
@talIguaz FYI. (We discussed in the context of the Frames README that we shouldn't document and demonstrate return values for `write`.)