### PR TITLE
Fix real-time user segmentation demo stream partitioning

### DIFF
--- a/demos/slots-stream/real-time-user-segmentation.ipynb
+++ b/demos/slots-stream/real-time-user-segmentation.ipynb
@@ -217,7 +217,23 @@
     "# Delete the stream if it exists\n",
     "client.delete(backend=\"stream\", table=TABLE, if_missing=fpb.IGNORE)\n",
     "# Create a new stream\n",
-    "client.create(backend=\"stream\", table=TABLE, shards=SHARDS_COUNT, retention_hours=DURATION_HOURS)"
+    "client.create(backend=\"stream\", table=TABLE, shards=SHARDS_COUNT, retention_hours=DURATION_HOURS)\n",
+    "\n",
+    "url = 'http://v3io-webapi:8081/users/' + os.getenv('V3IO_USERNAME') + '/examples/' + STREAM + '/'\n",
+    "headers = {\n",
+    "            \"Content-Type\": \"application/json\",\n",
+    "            \"X-v3io-function\": \"PutRecords\",\n",
+    "            \"X-v3io-session-key\": os.getenv('V3IO_ACCESS_KEY')\n",
+    "          }\n",
+    "\n",
+    "records = []\n",
+    "\n",
+    "def send_payload(records):\n",
+    "    if (len(records) > 0):\n",
+    "        payload = {\n",
+    "            \"Records\": records\n",
+    "        }\n",
+    "        requests.post(url, json=payload, headers=headers, verify=False)"
    ]
   },
   {
@@ -282,18 +298,15 @@
    "source": [
     "# nuclio: ignore\n",
     "# Prepare purchases data to write\n",
-    "data = []\n",
-    "keys = []\n",
     "for i in tqdm.tqdm(range(len_purchases)):\n",
     "    key = list(purchase_sequence[i].keys())[0]\n",
-    "    keys.append(str(key))\n",
-    "    data.append(f'{purchase_sequence[i][key]},{timestamps_list[i]},{key}')\n",
+    "    data = str(b64encode(f'{purchase_sequence[i][key]},{timestamps_list[i]},{key}'.encode(\"UTF-8\")), \"UTF-8\")\n",
+    "    records.append({\"Data\": data, \"PartitionKey\": str(key)})\n",
     "    if i % 1000 == 0:\n",
-    "        data = []\n",
-    "        keys = []\n",
-    "df = pd.DataFrame(data=data, columns=[\"data\"])\n",
-    "# Write the data to the stream\n",
-    "client.write(backend=\"stream\", table=TABLE, dfs=df, partition_keys=keys)"
+    "        send_payload(records)\n",
+    "        records = []\n",
+    "send_payload(records)\n",
+    "records = []"
    ]
   },
   {
@@ -320,20 +333,15 @@
    "source": [
     "# nuclio: ignore\n",
     "# Prepare spins data to write\n",
-    "data = []\n",
-    "keys = []\n",
     "for i in tqdm.tqdm(range(len_spins)):\n",
     "    key = list(spin_sequence[i].keys())[0]\n",
-    "    data.append(f'{spin_sequence[i][key]},{timestamps_list[i]},{key}')\n",
-    "    keys.append(str(key))\n",
+    "    data = str(b64encode(f'{spin_sequence[i][key]},{timestamps_list[i]},{key}'.encode(\"UTF-8\")), \"UTF-8\")\n",
+    "    records.append({\"Data\": data, \"PartitionKey\": str(key)})\n",
     "    if i % 1000 == 0:\n",
-    "        df = pd.DataFrame(data=data, columns=[\"data\"])\n",
-    "        client.write(backend=\"stream\", table=TABLE, dfs=df, partition_keys=keys)\n",
-    "        data = []\n",
-    "        keys = []\n",
-    "df = pd.DataFrame(data=data, columns=[\"data\"])\n",
-    "# Write the data to the stream\n",
-    "client.write(backend=\"stream\", table=TABLE, dfs=df, partition_keys=keys)"
+    "        send_payload(records)\n",
+    "        records = []\n",
+    "send_payload(records)\n",
+    "records = []"
    ]
   },
   {
@@ -1083,12 +1091,11 @@
     "            context.user_data.start_time = time.time()\n",
     "\n",
     "        # Extract action parameters\n",
-    "        raw = event.body.decode().strip()\n",
-    "        msg = json.loads(raw)\n",
-    "        action, timestamp, user_id = msg['data'].split(',')\n",
+    "        msg = event.body.decode().strip()\n",
+    "        action, timestamp, user_id = msg.split(',')\n",
     "\n",
     "        if context.user_data.processed_events % 10000 == 0:\n",
-    "            context.logger.debug(\"sample event: \" + raw)\n",
+    "            context.logger.debug(\"sample event: \" + msg)\n",
     "            context.logger.debug(\"context.user_data.processed_events=\" + str(context.user_data.processed_events) + \"\\n\" + str(context))\n",
     "\n",
     "        # Current time in seconds of epoch\n",


### PR DESCRIPTION
This change removes the frames client writes, which were using partition_keys field, from the real-time user segmentation notebook and replaces them with streams webapi putrecord requests with the PartitionKey field supplied.