### PR TITLE
Replace collect-n-explore.ipynb links with getting-started-basic.ipynb

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For a more in-depth introduction to the platform, see the following resources:
 <!-- [c-arch-page-update] IG-14804 TODO: When the doc architecture page is updated, return this link after the intro video: -->
 <!-- - [Unique data-layer architecture](https://www.iguazio.com/docs/intro/latest-release/architecture/) -->
 
-A good place to start your development is with the platform [tutorial Jupyter notebooks](https://github.com/v3io/tutorials), which are available in the home directory of the platform's Jupyter Notebook service; see especially the [getting-started examples](getting-started/collect-n-explore.ipynb) and full [use-case demo applications](demos/README.ipynb).
+A good place to start your development is with the platform [tutorial Jupyter notebooks](https://github.com/v3io/tutorials), which are available in the home directory of the platform's Jupyter Notebook service; see especially the [getting-started examples](getting-started/getting-started-basic.ipynb) and full [use-case demo applications](demos/README.ipynb).
 You can find a tutorials overview in the [Jupyter Notebook Basics](#jupyter-notebook-basics) section of this document.
 
 <a id="data-science-workflow"></a>
@@ -117,7 +117,7 @@ This design, coupled with the platform's unified data model, enables users to st
 
 > **Note:** You can deploy and manage application services, such as Spark and Jupyter Notebook, from the **Services** page of the platform dashboard.
 
-For more information and examples of data exploration with the platform, see the [**collect-n-explore**](getting-started/collect-n-explore.ipynb#gs-data-exploration-and-processing) tutorial Jupyter notebook.
+For more information and examples of data exploration with the platform, see the [**getting-started-basic**](getting-started/getting-started-basic.ipynb#gs-data-exploration-and-processing) tutorial Jupyter notebook.
 
 <a id="building-and-training-models"></a>
 ### Building and Training Models
@@ -229,7 +229,7 @@ The home directory of the platform's Jupyter Notebook service contains the follo
   - [**demos**](demos/README.ipynb) &mdash; a directory containing [end-to-end use-case application demos](#end-to-end-use-case-applications).
   - Scripts and related notebooks for [updating the tutorial notebooks](#update-notebooks) and [downloading additional demo applications](#mlrun-demos-download).
 
-For information about the predefined data containers and how to reference data in these containers, see [Platform Data Containers](getting-started/collect-n-explore.ipynb/#platform-data-containers) in the [**getting-started-basic**](getting-started/getting-started-basic.ipynb) tutorial notebook.
+For information about the predefined data containers and how to reference data in these containers, see [Platform Data Containers](getting-started/getting-started-basic.ipynb/#platform-data-containers) in the [**getting-started-basic**](getting-started/getting-started-basic.ipynb) tutorial notebook.
 
 <a id="creating-virtual-environments-in-jupyter-notebook"></a>
 ### Creating Virtual Environments in Jupyter Notebook

--- a/getting-started/parquet-read-write.ipynb
+++ b/getting-started/parquet-read-write.ipynb
@@ -303,7 +303,7 @@
     "\n",
     "Write the CSV data that was read into the pandas DataFrame to a Parquet table in a platform data container (i.e., in the distributed file system of the Iguazio Data Science Platform).\n",
     "\n",
-    "> **Note:** For information about using the `v3io` or `User` data mounts to reference data in the platform's data containers, see [Platform Data Containers](collect-n-explore.ipynb/#platform-data-containers) in the **getting-started/collect-n-explore.ipynb** notebook."
+    "> **Note:** For information about using the `v3io` or `User` data mounts to reference data in the platform's data containers, see [Platform Data Containers](getting-started-basic.ipynb/#platform-data-containers) in the **getting-started/getting-started-basic.ipynb** notebook."
    ]
   },
   {

--- a/getting-started/virtual-env.ipynb
+++ b/getting-started/virtual-env.ipynb
@@ -79,7 +79,7 @@
     "    ```sh\n",
     "    conda env export -n myenv > /v3io/users/$V3IO_USERNAME/virtual_env/myenv.yaml\n",
     "    ```\n",
-    "    You can use the `User` data mount to the running-user directory to shorten this command (see [Platform Data Containers](collect-n-explore.ipynb/#platform-data-containers)):\n",
+    "    You can use the `User` data mount to the running-user directory to shorten this command (see [Platform Data Containers](getting-started-basic.ipynb/#platform-data-containers)):\n",
     "    ```sh\n",
     "    conda env -n myenv export > /User/virtual_env/myenv.yaml\n",
     "    ```\n",

--- a/welcome.ipynb
+++ b/welcome.ipynb
@@ -79,7 +79,7 @@
     "<!-- [c-arch-page-update] IG-14804 TODO: When the doc architecture page is updated, return this link after the intro video: -->\n",
     "<!-- - [Unique data-layer architecture](https://www.iguazio.com/docs/intro/latest-release/architecture/) -->\n",
     "\n",
-    "A good place to start your development is with the platform [tutorial Jupyter notebooks](https://github.com/v3io/tutorials), which are available in the home directory of the platform's Jupyter Notebook service; see especially the [getting-started examples](getting-started/collect-n-explore.ipynb) and full [use-case demo applications](demos/README.ipynb).\n",
+    "A good place to start your development is with the platform [tutorial Jupyter notebooks](https://github.com/v3io/tutorials), which are available in the home directory of the platform's Jupyter Notebook service; see especially the [getting-started examples](getting-started/getting-started-basic.ipynb) and full [use-case demo applications](demos/README.ipynb).\n",
     "You can find a tutorials overview in the [Jupyter Notebook Basics](#jupyter-notebook-basics) section of this document."
    ]
   },
@@ -148,7 +148,7 @@
     "\n",
     "> **Note:** You can deploy and manage application services, such as Spark and Jupyter Notebook, from the **Services** page of the platform dashboard.\n",
     "\n",
-    "For more information and examples of data exploration with the platform, see the [**collect-n-explore**](getting-started/collect-n-explore.ipynb#gs-data-exploration-and-processing) tutorial Jupyter notebook."
+    "For more information and examples of data exploration with the platform, see the [**getting-started-basic**](getting-started/getting-started-basic.ipynb#gs-data-exploration-and-processing) tutorial Jupyter notebook."
    ]
   },
   {
@@ -294,7 +294,7 @@
     "  - [**demos**](demos/README.ipynb) &mdash; a directory containing [end-to-end use-case application demos](#end-to-end-use-case-applications).\n",
     "  - Scripts and related notebooks for [updating the tutorial notebooks](#update-notebooks) and [downloading additional demo applications](#mlrun-demos-download).\n",
     "\n",
-    "For information about the predefined data containers and how to reference data in these containers, see [Platform Data Containers](getting-started/collect-n-explore.ipynb/#platform-data-containers) in the [**getting-started-basic**](getting-started/getting-started-basic.ipynb) tutorial notebook."
+    "For information about the predefined data containers and how to reference data in these containers, see [Platform Data Containers](getting-started/getting-started-basic.ipynb/#platform-data-containers) in the [**getting-started-basic**](getting-started/getting-started-basic.ipynb) tutorial notebook."
    ]
   },
   {


### PR DESCRIPTION
The **getting-started/** **collect-n-explore.ipynb** was renamed to **getting-started-basic.ipynb** in PR #174 but some references to the old NB name remained in the tutorial NBs. => Fixed in this PR.

@adiso75 @gilad-shaham FYI