### PR TITLE
Revert PR #226 (incorrect edit of getting-started/gpu-cudf-vs-pd.ipynb)

### DIFF
--- a/getting-started/gpu-cudf-vs-pd.ipynb
+++ b/getting-started/gpu-cudf-vs-pd.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Performance Comparison &mdash; pandas Versus RAPIDS cuDF\n",
     "\n",
-    "This tutorial uses `timeit` to compare performance benchmarks with pandas and RAPIDS cuDF"
+    "This tutorial uses `timeit` to compare performance benchmarks with pandas and RAPIDS cuDF."
    ]
   },
   {


### PR DESCRIPTION
This reverts commit ff09064defd90df00d44bcdf85dd70fdade6fccf.

The problem that PR #226 attempted to fix was on the `master` branch only — in a previous `development` > `master` merge, **getting-started/gpu-cudf-vs-pd.ipynb** was committed on `master` with merge conflicts (https://github.com/v3io/tutorials/commit/9cc38430b8647460034988e6b4681c518920209b#diff-e4135fb30d257cf4a16cc8e82412ecac). The removal of the period in the Markdown cell in PR #226, on the `development` branch, has nothing to do with the problem that it tried to fix, so it was agreed to revert it. I will fix this `master` branch issue in a separate PR.