### PR TITLE
getting-started-tutorial: minor syntax fix (</> MD escaping)

### DIFF
--- a/getting-started-tutorial/getting-started-tutorial.ipynb
+++ b/getting-started-tutorial/getting-started-tutorial.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "Projects are visible in the MLRun dashboard only after they're saved to the MLRun database, which happens whenever you run code for a project.\n",
     "\n",
-    "The following code creates a project named \"getting-started-iris-\\<V3IO_USERNAME\\>\", where **\\<V3IO_USERNAME\\>** is your current running username in the platform, and sets the project directory to a **conf** directory in the current tutorial directory (**/User/getting-started-tutorial/conf**).\n",
+    "The following code creates a project named \"getting-started-iris-&lt;V3IO_USERNAME&gt;\", where **&lt;V3IO_USERNAME&gt;** is your current running username in the platform, and sets the project directory to a **conf** directory in the current tutorial directory (**/User/getting-started-tutorial/conf**).\n",
     "\n",
     "> **Note:** Platform projects are shared among all users of the parent tenant, to facilitate collaboration. Therefore,\n",
     ">\n",


### PR DESCRIPTION
The output for the original `\<`/`\>` syntax used in the NB (for V3IO_USERNAME) looks OK when the NB is viewed in Jupyter Notebook, but on GitHub there's a slash (`\`) before the `<` tag ("\<"), so I replaced it with our customer syntax of `&lt;` and `&gt;` tags.